### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/edburns-msft/38da57f4-82b4-477d-b348-01f441027a7d/e8e26923-377f-4f7b-894b-b121347a76f8/_apis/work/boardbadge/c3c5b901-aba3-4826-9dc1-43e18c51adbf)](https://dev.azure.com/edburns-msft/38da57f4-82b4-477d-b348-01f441027a7d/_boards/board/t/e8e26923-377f-4f7b-894b-b121347a76f8/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#3652](https://dev.azure.com/edburns-msft/38da57f4-82b4-477d-b348-01f441027a7d/_workitems/edit/3652). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.